### PR TITLE
Fix missing method in config manager

### DIFF
--- a/src/main/java/org/craftllc/minecraft/mod/cycm/config/ModConfigManager.java
+++ b/src/main/java/org/craftllc/minecraft/mod/cycm/config/ModConfigManager.java
@@ -40,6 +40,11 @@ public class ModConfigManager {
         return config;
     }
 
+    // Method to get the mod's configuration directory
+    public Path getModConfigDir() {
+        return FabricLoader.getInstance().getConfigDir();
+    }
+
     // Метод для завантаження конфігурації з файлу
     public void loadConfig() {
         try {


### PR DESCRIPTION
Add `getModConfigDir()` to `ModConfigManager` to resolve a compilation error in `AIClient`.

`AIClient.java` was attempting to retrieve the mod's configuration directory via `CYCMClient.configManager.getModConfigDir()`, but this method was missing from the `ModConfigManager` class. This PR adds the method, correctly utilizing `FabricLoader.getInstance().getConfigDir()` to provide the necessary path.